### PR TITLE
Address build warnings related to CPP.

### DIFF
--- a/src/Miso/Native.hs
+++ b/src/Miso/Native.hs
@@ -44,16 +44,17 @@ module Miso.Native
    ) where
 -----------------------------------------------------------------------------
 import Miso (renderComponent, Component)
-import Miso.String (MisoString)
 import Miso.Native.Element
 import Miso.Native.FFI
 import Miso.Native.Event
 -----------------------------------------------------------------------------
 import Control.Monad (void)
+import Language.Javascript.JSaddle (JSM)
 #ifndef GHCJS_BOTH
 import Data.FileEmbed (embedStringFile)
+import Language.Javascript.JSaddle (eval)
+import Miso.String (MisoString)
 #endif
-import Language.Javascript.JSaddle (eval, JSM)
 -----------------------------------------------------------------------------
 native :: Eq model => Component name model action -> JSM ()
 native vcomp = withJS $ renderComponent (Just "native") vcomp (pure ())


### PR DESCRIPTION
Properly CPPs the build. When doing dev w/ hot-reload the `eval` call will load the JS into the simulator (when dev'ing w/ GHC). This is still a WIP and the "Haskell version" of HMR.

- [x] Ensures warnings no longer occur during GHCJS / GHC builds.