### PR TITLE
Add `takeScreenshot`, `requestAccessiblityFocus` to `View.FFI`

### DIFF
--- a/src/Miso/Native/Element/View/FFI.hs
+++ b/src/Miso/Native/Element/View/FFI.hs
@@ -20,8 +20,10 @@ module Miso.Native.Element.View.FFI
   -- *** Types
   , Rect (..)
   , BoundingClientRect (..)
+  , TakeScreenshot (..)
   -- *** Smart constructors
   , defaultBoundingClientRect
+  , defaultTakeScreenshot
   ) where
 -----------------------------------------------------------------------------
 import Control.Monad
@@ -54,35 +56,21 @@ instance FromJSVal Rect where
     bottom <- readProp "bottom"
     pure $ Just Rect {..}
 -----------------------------------------------------------------------------
-data BoundingClientRect action
+data BoundingClientRect
   = BoundingClientRect
-  { successful :: Rect -> action
-  -- ^ Successful callback
-  , errorful :: MisoString -> action
-  -- ^ Errorful callback
-  , selector :: MisoString
-  -- ^ Selector identifier (e.g. "#box")
-  , androidEnableTransformProps :: Bool
+  { androidEnableTransformProps :: Bool
   -- ^ Specifies whether to consider the transform attribute
   -- when calculating the position on Android. The default value is 'False'
   , relativeTo :: Maybe JSVal
   -- ^ Specify the reference node, relative to LynxView by default.
   }
 -----------------------------------------------------------------------------
--- | Smart constructor for calling 'boundingClientRect'
+-- | Smart constructor for constructing 'boundingClientRect'
+defaultBoundingClientRect :: BoundingClientRect
 defaultBoundingClientRect
-  :: MisoString
-  -- ^ Selector (e.g. "#box")
-  -> (Rect -> action)
-  -- ^ Successful callback (contains 'Rect')
-  -> (MisoString -> action)
-  -- ^ Errorful callback, contains error message
-  -> BoundingClientRect action
-defaultBoundingClientRect selector successful errorful
   = BoundingClientRect
   { androidEnableTransformProps = True
   , relativeTo = Nothing
-  , ..
   }
 -----------------------------------------------------------------------------
 -- | https://lynxjs.org/api/elements/built-in/view.html#boundingclientrect
@@ -97,8 +85,8 @@ defaultBoundingClientRect selector successful errorful
 --   | GetRect
 --
 -- update :: Action -> Effect model Action
--- update GetRect = boundingClientRect
---   (defaultBoundingClientRect "#box" Success Failure)
+-- update GetRect =
+--   boundingClientRect defaultBoundingClientRect "#box" Success Failure
 -- update (Succes Rect {..}) =
 --   consoleLog "Successfuly got Rect"
 -- update (Failure errorMsg) =
@@ -107,35 +95,145 @@ defaultBoundingClientRect selector successful errorful
 -- @
 --
 boundingClientRect
-  :: BoundingClientRect action
+  :: BoundingClientRect
+  -> MisoString
+  -> (Rect -> action)
+  -> (MisoString -> action)
   -> Effect model action
-boundingClientRect BoundingClientRect {..} = withSink $ \sink -> do
+boundingClientRect BoundingClientRect {..} selector successful errorful =
+  withSink $ \sink -> do
+    selector_ <- toJSVal selector
+    successful_ <- toJSVal =<< do
+      asyncCallback1 $ \arg -> do
+        rect <- fromJSValUnchecked arg
+        sink (successful rect)
+    errorful_ <- toJSVal =<< do
+      asyncCallback1 $ \arg -> do
+        rect <- fromJSValUnchecked arg
+        sink (errorful rect)
+    params <- create
+    set "androidEnableTransformProps" androidEnableTransformProps params
+    set "relativeTo" relativeTo params
+    params_ <- toJSVal params
+    method__ <- toJSVal ("boundingClientRect" :: MisoString)
+    void $ do
+      jsg ("globalThis" :: MisoString) # ("invokeExec" :: MisoString) $
+        [ selector_
+        , method__
+        , params_
+        , successful_
+        , errorful_
+        ]
+-----------------------------------------------------------------------------
+data TakeScreenshot
+  = TakeScreenshot
+  { format_ :: MisoString 
+  -- ^ e.g. Specify the image format, supports jpeg and png, the default is jpeg
+  , scale_ :: Double
+  -- ^ e.g. Specify the image quality, 0 < scale <= 1, the default is 1,
+  -- the smaller the value, the blurrier and smaller the size.
+  }
+-----------------------------------------------------------------------------
+-- | https://lynxjs.org/api/elements/built-in/view.html#takescreenshot
+--
+-- The front end can execute 'takeScreenshot' through the SelectorQuery API.
+--
+-- @
+--
+-- data Action
+--   = Success Image
+--   | Failure MisoString
+--   | GetScreenshot
+--
+-- update :: Action -> Effect model Action
+-- update GetScreenshot = takeScreenshot
+--   defaultTakeScreenshot "#my-view" Success Failure
+-- update (Succes image) =
+--   consoleLog "Successfuly got image"
+--   consoleLog' image
+-- update (Failure errorMsg) =
+--   consoleLog ("Failed to call takeScreenshot: " <> errorMsg)
+--
+-- @
+--
+takeScreenshot
+  :: TakeScreenshot
+  -> MisoString
+  -> (Image -> action)
+  -> (MisoString -> action)
+  -> Effect model action
+takeScreenshot TakeScreenshot {..} selector successful errorful = withSink $ \sink -> do
   selector_ <- toJSVal selector
   successful_ <- toJSVal =<< do
     asyncCallback1 $ \arg -> do
-      rect <- fromJSValUnchecked arg
-      sink (successful rect)
+      sink (successful (Image arg))
   errorful_ <- toJSVal =<< do
     asyncCallback1 $ \arg -> do
       rect <- fromJSValUnchecked arg
       sink (errorful rect)
   params <- create
-  set "androidEnableTransformProps" androidEnableTransformProps params
-  set "relativeTo" relativeTo params
+  set "scale" scale_ params
+  set "format" format_ params
   params_ <- toJSVal params
-  method__ <- toJSVal ("boundingClientRect" :: MisoString)
+  method <- toJSVal ("takeScreenshot" :: MisoString)
   void $ do
     jsg ("globalThis" :: MisoString) # ("invokeExec" :: MisoString) $
       [ selector_
-      , method__
+      , method
       , params_
       , successful_
       , errorful_
       ]
 -----------------------------------------------------------------------------
-takeScreenshot :: JSM ()
-takeScreenshot = undefined
+-- | Smart constructor for calling 'TakeScreenshot'
+defaultTakeScreenshot :: TakeScreenshot
+defaultTakeScreenshot
+  = TakeScreenshot
+  { scale_ = 0.5
+  , format_ = ".png"
+  }
 -----------------------------------------------------------------------------
-requestAccessibilityFocus :: JSM ()
-requestAccessibilityFocus = undefined
+-- | https://lynxjs.org/api/elements/built-in/view.html#requestaccessibilityfocus
+--
+-- The front end can execute 'requestAccessiblityFocus' through the SelectorQuery API.
+--
+-- @
+--
+-- data Action
+--   = Success
+--   | Failure MisoString
+--   | GetFocus
+--
+-- update :: Action -> Effect model Action
+-- update GetFocus = requestAccessibilityFocus "#my-view" Success Failure
+-- update Success = consoleLog "Successfuly got focus"
+-- update (Failure errorMsg) =
+--   consoleLog ("Failed to call requestAccessibilityFocus: " <> errorMsg)
+--
+-- @
+--
+requestAccessibilityFocus
+  :: MisoString
+  -> (Image -> action)
+  -> (MisoString -> action)
+  -> Effect model action
+requestAccessibilityFocus selector successful errorful = withSink $ \sink -> do
+  selector_ <- toJSVal selector
+  successful_ <- toJSVal =<< do
+    asyncCallback1 $ \arg -> do
+      sink (successful (Image arg))
+  errorful_ <- toJSVal =<< do
+    asyncCallback1 $ \arg -> do
+      error_ <- fromJSValUnchecked arg
+      sink (errorful error_)
+  params_ <- toJSVal =<< create
+  method <- toJSVal ("requestAccessibilityFocus" :: MisoString)
+  void $ do
+    jsg ("globalThis" :: MisoString) # ("invokeExec" :: MisoString) $
+      [ selector_
+      , method
+      , params_
+      , successful_
+      , errorful_
+      ]
 -----------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Adds two more FFI method calls for view

Based on work done in `getBoundingClientRect`. This also factors out the successful and errorful callbacks out as parameters.