### PR TITLE
Add `-sEXPORTED_RUNTIME_METHODS=HEAP8`

### DIFF
--- a/examples/miso-native-examples.cabal
+++ b/examples/miso-native-examples.cabal
@@ -19,7 +19,7 @@ common options
 
   if arch(javascript)
     ld-options:
-      -sENVIRONMENT=shell -sWASM=0
+      -sENVIRONMENT=shell -sWASM=0 -sEXPORTED_RUNTIME_METHODS=HEAP8 
 
 executable counter
   import:


### PR DESCRIPTION
Add exported runtime methods for JavaScript build