### PR TITLE
Fix NS -> Namesapce

### DIFF
--- a/src/Miso/Lynx/Element.hs
+++ b/src/Miso/Lynx/Element.hs
@@ -34,7 +34,7 @@ import           Miso.JSON (toJSON)
 import           Miso.Lynx.Element.List (ListOptions(..))
 import           Miso.Property (textProp, prop)
 import           Miso.String (MisoString)
-import           Miso.Types (View, Attribute, node, NS(HTML))
+import           Miso.Types (View, Attribute, node, Namespace(HTML))
 -----------------------------------------------------------------------------
 -- | Smart constructor for constructing a built-in lynx element.
 --


### PR DESCRIPTION
This PR address the compilation error below:
```
Compiling Miso.Lynx.Element ( src/Miso/Lynx/Element.hs, dist/build/Miso/Lynx/Element.o )
src/Miso/Lynx/Element.hs:37:53: error: [GHC-61689]
    Module ‘Miso.Types’ does not export ‘NS’.
    Suggested fix: Perhaps use ‘JS’
   |
37 | import           Miso.Types (View, Attribute, node, NS(HTML))
   |                                                     ^^^^^^^^
```
Base on [this](https://github.com/dmjio/miso/blame/1.9.0/src/Miso/Types.hs#L38), the `NS` type has renamed to `Namespace`.