### PR TITLE
Update miso to 998854f (latest master)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,4 +14,4 @@ package miso
 source-repository-package
   type: git
   location: https://github.com/dmjio/miso.git
-  tag: master
+  tag: 998854f34040a7e3be1ef460226b835ff57a3cc1

--- a/examples/counter/Main.hs
+++ b/examples/counter/Main.hs
@@ -37,7 +37,7 @@ data Action
 -----------------------------------------------------------------------------
 -- | Entry point for a native miso application
 main :: IO ()
-main = native nativeEvents (static (mountStatic_ counterComponent))
+main = native nativeEvents (static (mountStatic counterComponent))
 -----------------------------------------------------------------------------
 counterComponent :: Component () () Model Action
 counterComponent = component (Model 0) updateModel viewModel

--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1787014807,
-        "narHash": "sha256-CVDlH2592vQJuKTNIpbxOGZ/SzErTJ7yEfPLe+5HfzE=",
+        "lastModified": 1787456262,
+        "narHash": "sha256-0mMCYlwo63zgdh941fb6GNesd2asrD2USa7drdKsSTQ=",
         "owner": "dmjio",
         "repo": "miso",
-        "rev": "39d58742823a1cab2f6a9ca09ba359180c27c22b",
+        "rev": "998854f34040a7e3be1ef460226b835ff57a3cc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the pinned `miso` revision to the latest master commit `998854f34040a7e3be1ef460226b835ff57a3cc1`.

- `cabal.project`: pin the `source-repository-package` tag to the exact commit (was `master`)
- `flake.lock`: update the `miso` flake input to the same revision
- `examples/counter/Main.hs`: `mountStatic_` was renamed to `mountStatic` upstream

Verified locally: `nix build .#miso-lynx-examples` and `nix build .#counter-bundle` both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCKqa1qvF5fUk3Si7uUB88